### PR TITLE
Parameterize`my.cnf` 

### DIFF
--- a/fix_it.sh
+++ b/fix_it.sh
@@ -93,8 +93,9 @@ convert_field() {
   proccess_change_field $TABLE "$FIELD_RAW"
 }
 
+MY_CNF=${MY_CNF:-/root/.my.cnf}
 
-mysql="sudo mysql --defaults-file=/root/.my.cnf"
+mysql="sudo mysql --defaults-file=${MY_CNF}"
 
 readarray -t TABLES < <($mysql -e "SHOW TABLE STATUS WHERE Collation='latin1_swedish_ci'\G" | grep Name | sed  's/Name://g' | awk '{$1=$1;print}')
 


### PR DESCRIPTION
## What
* Made mysql default file as parameter

## Why
* If you have several db to run that script it is useful to have several .my.cnf