### PR TITLE
Fix typos in README. Add changing default charset for database

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Install
 
-* Install [pv](https://github.com/icetee/pv]) tool
+* Install [pv](https://github.com/icetee/pv) tool
 * Install script
   ```shell
   curl https://raw.githubusercontent.com/cloudposse/mysql_fix_encoding/4.0/fix_it.sh -o /usr/local/bin/mysql_latin_utf8.sh
@@ -31,7 +31,7 @@ You should have exited db with some tables or fields in latin1 encoding.
 
 3) Run convert db with command
 
-    `$ MY_CNF=/home/${user}/my.cnf /usr/local/bin/mysql_latin_utf8.sh | pv | sudo mysql --defaults-file=/home/${user}/.my.cnf`
+    `$ MY_CNF=/home/${user}/my.cnf /usr/local/bin/mysql_latin_utf8.sh | pv | sudo mysql --defaults-file=/home/${user}/my.cnf`
 
 ## Extra
 

--- a/fix_it.sh
+++ b/fix_it.sh
@@ -219,3 +219,5 @@ for TABLE in "${TABLES[@]}"; do
   create_fulltexts $TABLE
   creates_constraints $TABLE
 done
+
+$MYSQL -e "ALTER DATABASE ${DB} CHARACTER SET = 'utf8'  COLLATE = 'utf8_general_ci';" 2>&1 | grep -v "$SILENT_WARNING"


### PR DESCRIPTION
## What
* Fix two typos in README
* Add command to change default character setting for DB

## Why
* After database is converted new tables will be created with the improper charset